### PR TITLE
Add threshold to ControlCostArea; bug fix in sum over controls 

### DIFF
--- a/qontrol/cost.py
+++ b/qontrol/cost.py
@@ -6,7 +6,7 @@ import jax.tree_util as jtu
 from jax.nn import relu
 from dynamiqs import asqarray, isket, QArray, QArrayLike, TimeQArray
 from dynamiqs.result import PropagatorResult, SolveResult
-from dynamiqs.time_qarray import SummedTimeQArray
+from dynamiqs.time_qarray import SummedTimeQArray, ConstantTimeQArray
 from jax import Array, vmap
 
 
@@ -433,8 +433,8 @@ class ControlCost(Cost):
         self, result: SolveResult, H: TimeQArray, func: callable
     ) -> Array:
         def _evaluate_at_tsave(_H: TimeQArray) -> Array:
-            if hasattr(_H, 'prefactor'):
-                return jnp.sum(func(vmap(_H.prefactor)(result.tsave)))
+            if not isinstance(_H, ConstantTimeQArray):
+                return jnp.sum(func(_H.prefactor(result.tsave)))
             return jnp.array(0.0)
 
         if isinstance(H, SummedTimeQArray):

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -221,8 +221,7 @@ def loss(
 ) -> [float, Array]:
     result, H = model(parameters, method, gradient, dq_options)
     cost_values, terminate = zip(*costs(result, H, parameters), strict=True)
-    total_cost = jax.tree.reduce(jnp.add, cost_values)
-    total_cost = jnp.log(jnp.sum(jnp.asarray(total_cost)))
+    total_cost = jnp.log(jax.tree.reduce(jnp.add, cost_values))
     expects = result.expects if hasattr(result, 'expects') else None
     return total_cost, (total_cost, cost_values, terminate, expects)
 

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -6,7 +6,6 @@ from functools import partial
 import dynamiqs as dq
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method, Tsit5
@@ -140,7 +139,7 @@ def optimize(
             parameters, grads, opt_state, aux = jax.block_until_ready(
                 step(parameters, costs, model, opt_state, method, gradient, dq_options)
             )
-            elapsed_time = np.around(time.time() - epoch_start_time, decimals=3)
+            elapsed_time = jnp.round(time.time() - epoch_start_time, decimals=3)
             total_cost, cost_values, terminate_for_cost, expects = aux
             cost_values_over_epochs.append(cost_values)
             epoch_times.append(elapsed_time)
@@ -196,14 +195,16 @@ def optimize(
             cost_values_over_epochs,
             len(cost_values_over_epochs) - 1,
         )
+
+    epoch_times = jnp.array(epoch_times)
     if not opt_options['ignore_termination']:
         print(TERMINATION_MESSAGES[termination_key])
     print(
         f'optimization terminated after {epoch} epochs; \n'
         f'average epoch time (excluding jit) of '
-        f'{np.around(np.mean(epoch_times[1:]), decimals=5)} s; \n'
-        f'max epoch time of {np.max(epoch_times[1:])} s; \n'
-        f'min epoch time of {np.min(epoch_times[1:])} s'
+        f'{jnp.round(jnp.mean(epoch_times[1:]), decimals=5)} s; \n'
+        f'max epoch time of {jnp.max(epoch_times[1:])} s; \n'
+        f'min epoch time of {jnp.min(epoch_times[1:])} s'
     )
     if opt_options['verbose'] and filepath is not None:
         print(f'results saved to {filepath}')
@@ -255,7 +256,7 @@ def _terminate_early(
     if dg < opt_options['gtol']:
         termination_key = 1
     # ftol
-    dF = np.abs(total_cost - prev_total_cost)
+    dF = jnp.abs(total_cost - prev_total_cost)
     if dF < opt_options['ftol'] * total_cost:
         termination_key = 2
     if dx < opt_options['xtol'] * (opt_options['xtol'] + dx):
@@ -270,5 +271,5 @@ def _terminate_early(
 
 def _norm(x: Array) -> Array:
     if x.shape == ():
-        return np.abs(x)
-    return np.linalg.norm(x, ord=np.inf)
+        return jnp.abs(x)
+    return jnp.max(jnp.abs(x))

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -6,6 +6,7 @@ from functools import partial
 import dynamiqs as dq
 import jax
 import jax.numpy as jnp
+import numpy as np
 import optax
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method, Tsit5
@@ -139,7 +140,7 @@ def optimize(
             parameters, grads, opt_state, aux = jax.block_until_ready(
                 step(parameters, costs, model, opt_state, method, gradient, dq_options)
             )
-            elapsed_time = jnp.round(time.time() - epoch_start_time, decimals=3)
+            elapsed_time = np.around(time.time() - epoch_start_time, decimals=3)
             total_cost, cost_values, terminate_for_cost, expects = aux
             cost_values_over_epochs.append(cost_values)
             epoch_times.append(elapsed_time)
@@ -156,7 +157,7 @@ def optimize(
 
             if filepath is not None:
                 data_dict = {
-                    'cost_values': jnp.asarray(cost_values),
+                    'cost_values': np.asarray(cost_values),
                     'total_cost': total_cost,
                 }
                 if type(parameters) is dict:
@@ -196,15 +197,14 @@ def optimize(
             len(cost_values_over_epochs) - 1,
         )
 
-    epoch_times = jnp.array(epoch_times)
     if not opt_options['ignore_termination']:
         print(TERMINATION_MESSAGES[termination_key])
     print(
         f'optimization terminated after {epoch} epochs; \n'
         f'average epoch time (excluding jit) of '
-        f'{jnp.round(jnp.mean(epoch_times[1:]), decimals=5)} s; \n'
-        f'max epoch time of {jnp.max(epoch_times[1:])} s; \n'
-        f'min epoch time of {jnp.min(epoch_times[1:])} s'
+        f'{np.around(np.mean(epoch_times[1:]), decimals=5)} s; \n'
+        f'max epoch time of {np.max(epoch_times[1:])} s; \n'
+        f'min epoch time of {np.min(epoch_times[1:])} s'
     )
     if opt_options['verbose'] and filepath is not None:
         print(f'results saved to {filepath}')

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -42,7 +42,7 @@ def get_controls(H: TimeQArray, tsave: np.ndarray) -> list[np.ndarray]:
     """Extract the Hamiltonian prefactors at the supplied times."""
 
     def evaluate_at_tsave(_H: TimeQArray) -> np.ndarray:
-        if hasattr(_H, 'prefactor'):
+        if not isinstance(_H, ConstantTimeQArray):
             return np.asarray(jax.vmap(_H.prefactor)(tsave))
         return np.zeros_like(tsave)
 

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import jax.numpy as jnp
+import numpy as np
 import matplotlib.pyplot as plt
 from dynamiqs.time_qarray import ConstantTimeQArray, SummedTimeQArray, TimeQArray
 from IPython.display import clear_output
 from jax import Array
 from matplotlib.pyplot import Axes
-from numpy import ndindex
 
 from .cost import Cost, SummedCost
 from .model import Model
@@ -19,15 +18,15 @@ def plot_costs(
 ) -> Axes:
     """Plot the evolution of the cost function values."""
     ax.set_facecolor('none')
-    epoch_range = jnp.arange(epoch + 1)
-    cost_values_over_epochs = jnp.asarray(cost_values_over_epochs).T
+    epoch_range = np.arange(epoch + 1)
+    cost_values_over_epochs = np.asarray(cost_values_over_epochs).T
     if isinstance(costs, SummedCost):
         for _cost, _cost_value in zip(
             costs.costs, cost_values_over_epochs, strict=True
         ):
             ax.plot(epoch_range, _cost_value, label=str(_cost))
         ax.plot(
-            epoch_range, jnp.sum(cost_values_over_epochs, axis=0), label='total cost'
+            epoch_range, np.sum(cost_values_over_epochs, axis=0), label='total cost'
         )
     else:
         ax.plot(epoch_range, cost_values_over_epochs[0], label=str(costs))
@@ -38,13 +37,13 @@ def plot_costs(
     return ax
 
 
-def get_controls(H: TimeQArray, tsave: Array) -> list[Array]:
+def get_controls(H: TimeQArray, tsave: np.ndarray) -> list[np.ndarray]:
     """Extract the Hamiltonian prefactors at the supplied times."""
 
-    def evaluate_at_tsave(_H: TimeQArray) -> Array:
+    def evaluate_at_tsave(_H: TimeQArray) -> np.ndarray:
         if not isinstance(_H, ConstantTimeQArray):
             return _H.prefactor(tsave)
-        return jnp.zeros_like(tsave)
+        return np.zeros_like(tsave)
 
     controls = []
     if isinstance(H, SummedTimeQArray):
@@ -68,7 +67,7 @@ def plot_controls(
     controls = get_controls(H, tsave)
     H_labels = [f'$H_{idx}$' for idx in range(len(controls))]
     for idx, control in enumerate(controls):
-        ax.plot(tsave, jnp.real(control), label=H_labels[idx])
+        ax.plot(tsave, np.real(control), label=H_labels[idx])
     ax.legend(loc='lower right', framealpha=0.0)
     ax.set_ylabel('pulse amplitude')
     ax.set_xlabel('time [ns]')
@@ -84,11 +83,11 @@ def plot_fft(
     tsave = model.tsave_function(parameters)
     controls = get_controls(H, tsave)
     for control_idx, control in enumerate(controls):
-        y_fft = jnp.fft.fft(control)
+        y_fft = np.fft.fft(control)
         n = len(control)
         dt = tsave[1] - tsave[0]
-        freqs = jnp.fft.fftfreq(n, dt)
-        ax.plot(freqs[: n // 2], jnp.abs(y_fft[: n // 2]), label=f'$H_{control_idx}$')
+        freqs = np.fft.fftfreq(n, dt)
+        ax.plot(freqs[: n // 2], np.abs(y_fft[: n // 2]), label=f'$H_{control_idx}$')
     ax.legend(loc='lower right', framealpha=0.0)
     ax.set_xlabel('frequency [GHz]')
     ax.set_ylabel('fourier amplitude')
@@ -104,9 +103,9 @@ def plot_expects(
     tsave = model.tsave_function(parameters)
     # plot all expectation values by default
     if expects is not None:
-        expect_idxs = ndindex(*expects.shape[:-1])
+        expect_idxs = np.ndindex(*expects.shape[:-1])
         for expect_idx in expect_idxs:
-            ax.plot(tsave, jnp.real(expects[tuple(expect_idx)]))
+            ax.plot(tsave, np.real(expects[tuple(expect_idx)]))
     ax.set_xlabel('time [ns]')
     ax.set_ylabel('expectation values')
     return ax
@@ -143,7 +142,7 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
         ```python
         import dynamiqs as dq
         import jax.numpy as jnp
-        from numpy import ndindex
+        import numpy as np
         import qontrol as ql
         from functools import partial
 
@@ -160,9 +159,9 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
         ) -> Axes:
             ax.set_facecolor('none')
             tsave = model.tsave_function(parameters)
-            batch_idxs = ndindex(*expects.shape[:-3])
+            batch_idxs = np.ndindex(*expects.shape[:-3])
             for batch_idx in batch_idxs:
-                ax.plot(tsave, jnp.real(expects[tuple(batch_idx), which, 0]))
+                ax.plot(tsave, np.real(expects[tuple(batch_idx), which, 0]))
             ax.set_xlabel('time [ns]')
             ax.set_ylabel(
                 f'population in $|1\\rangle$ for initial state $|{which}\\rangle$'
@@ -175,12 +174,12 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
         ) -> Axes:
             ax.set_facecolor('none')
             tsave = model.tsave_function(parameters)
-            finer_tsave = jnp.linspace(0.0, tsave[-1], 10 * len(tsave))
+            finer_tsave = np.linspace(0.0, tsave[-1], 10 * len(tsave))
             for idx, control in enumerate(parameters):
                 H_c = dq.pwc(tsave, control, H1s[idx])
                 ax.plot(
                     finer_tsave,
-                    jnp.real(H_c.prefactor(finer_tsave)) / 2 / jnp.pi,
+                    np.real(H_c.prefactor(finer_tsave)) / 2 / np.pi,
                     label=H1_labels[idx],
                 )
             ax.legend(loc='lower right', framealpha=0.0)
@@ -218,14 +217,14 @@ class Plotter:
     ):
         clear_output(wait=True)
         n_col = 4 if self.n_plots >= 4 else self.n_plots
-        n_rows = jnp.ceil(self.n_plots / n_col).astype(int)
+        n_rows = np.ceil(self.n_plots / n_col).astype(int)
         fig, axes = plt.subplots(n_rows, n_col, figsize=(n_col * 4, n_rows * 4))
         if n_rows == 1:
             axes = axes[None]
         fig.patch.set_alpha(0.1)
         axes[0, 0] = plot_costs(axes[0, 0], costs, epoch, cost_values_over_epochs)
         for plot_idx in range(self.n_plots - 1):
-            row_idx, col_idx = jnp.unravel_index(1 + plot_idx, (n_rows, n_col))
+            row_idx, col_idx = np.unravel_index(1 + plot_idx, (n_rows, n_col))
             axes[row_idx, col_idx] = self.plotting_functions[plot_idx](
                 axes[row_idx, col_idx], expects, model, parameters
             )

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import jax
 import matplotlib.pyplot as plt
 import numpy as np
 from dynamiqs.time_qarray import ConstantTimeQArray, SummedTimeQArray, TimeQArray
@@ -43,7 +42,7 @@ def get_controls(H: TimeQArray, tsave: np.ndarray) -> list[np.ndarray]:
 
     def evaluate_at_tsave(_H: TimeQArray) -> np.ndarray:
         if not isinstance(_H, ConstantTimeQArray):
-            return np.asarray(jax.vmap(_H.prefactor)(tsave))
+            return _H.prefactor(tsave)
         return np.zeros_like(tsave)
 
     controls = []
@@ -180,7 +179,7 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
                 H_c = dq.pwc(tsave, control, H1s[idx])
                 ax.plot(
                     finer_tsave,
-                    np.real(jax.vmap(H_c.prefactor)(finer_tsave)) / 2 / np.pi,
+                    np.real(H_c.prefactor(finer_tsave)) / 2 / np.pi,
                     label=H1_labels[idx],
                 )
             ax.legend(loc='lower right', framealpha=0.0)

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import matplotlib.pyplot as plt
 import jax.numpy as jnp
-from numpy import ndindex
+import matplotlib.pyplot as plt
 from dynamiqs.time_qarray import ConstantTimeQArray, SummedTimeQArray, TimeQArray
 from IPython.display import clear_output
 from jax import Array
 from matplotlib.pyplot import Axes
+from numpy import ndindex
 
 from .cost import Cost, SummedCost
 from .model import Model
@@ -94,6 +94,7 @@ def plot_fft(
     ax.set_ylabel('fourier amplitude')
     ax.grid(True)
     return ax
+
 
 def plot_expects(
     ax: Axes, expects: Array | None, model: Model, parameters: Array | dict

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from dynamiqs.time_qarray import ConstantTimeQArray, SummedTimeQArray, TimeQArray
 from IPython.display import clear_output
 from jax import Array


### PR DESCRIPTION
Bug fixes: 
- The control drive area is computed as a Riemann sum; however, the `dt` factor was missing. Fixed this bug.
- Fixed a bug caused by [dynamiqs #974](https://github.com/dynamiqs/dynamiqs/pull/974). The new `TimeQArray.prefactor()` method in the parent class now adds a prefactor to all children, including `ConstantTimeQArray`. Previously, `qontrol` checked for the presence or absence of a prefactor attribute, but now I check if a Hamiltonian is a `ConstantTimeQArray`.

Optimizations:
- Avoid computing propagator dim at every call
- Minimize numpy dependence
- Remove redundant line in loss()

Feature:
- Added a threshold for the control area, which is especially useful for bosonic control. When optimizing a pulse on a truncated oscillator, this helps prevent displacements beyond the Hilbert space cutoff.