### PR TITLE
Batched saving

### DIFF
--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -85,8 +85,8 @@ def optimize(
             epochs _(int)_: Number of optimization epochs.
             plot _(bool)_: Whether to plot the results during the optimization (for the
                 epochs where results are plotted, necessarily suffer a time penalty).
-            plot_period _(int)_: If plot is True, plot every plot_period.
-            save_period _(int)_: If filepath is provided, save every save_period. Defaults to 1.
+            plot_period _(int)_: If plot is True, plot every plot_period. Defaults to 30.
+            save_period _(int)_: If filepath is provided, save every save_period. Defaults to 30.
             xtol _(float)_: Defaults to 1e-8, terminate the optimization if the parameters
                 are not being updated
             ftol _(float)_: Defaults to 1e-8, terminate the optimization if the cost

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -37,6 +37,7 @@ default_options = {
     'epochs': 2000,
     'plot': True,
     'plot_period': 30,
+    'save_period': 30,
     'xtol': 1e-8,
     'ftol': 1e-8,
     'gtol': 1e-8,
@@ -103,9 +104,10 @@ def optimize(
     epoch_times = []
     previous_parameters = parameters
     prev_total_cost = 0.0
+    last_saved_epoch = -1
 
-    # check plotter
-    if plotter is None:
+    # Initialize plotter if needed
+    if plotter is None and opt_options['plot']:
         if (
             isinstance(model, SolveModel)
             and model.exp_ops is not None
@@ -144,6 +146,8 @@ def optimize(
             total_cost, cost_values, terminate_for_cost, expects = aux
             cost_values_over_epochs.append(cost_values)
             epoch_times.append(elapsed_time)
+            
+            # Print updated costs
             if opt_options['verbose']:
                 print(f'epoch: {epoch}, elapsed_time: {elapsed_time} s; ')
                 if isinstance(costs, SummedCost):
@@ -155,21 +159,29 @@ def optimize(
                 else:
                     print(costs, cost_values[0])
 
-            if filepath is not None:
+            # Save and/or plot
+            if filepath is not None and epoch % opt_options['save_period'] == 0 and epoch > 0:
+                if opt_options['verbose']:
+                    print(f'... saving data; from {last_saved_epoch+1} to {epoch}\n')
+                cost_since_last_saved = jnp.asarray(cost_values_over_epochs)[last_saved_epoch+1:]
                 data_dict = {
-                    'cost_values': jnp.asarray(cost_values),
-                    'total_cost': total_cost,
+                    'cost_values': cost_since_last_saved,
+                    'total_cost': jnp.sum(cost_since_last_saved, axis=-1),
                 }
                 if type(parameters) is dict:
-                    data_dict = data_dict | parameters
+                    for key, val in parameters.items():
+                        data_dict[key] = val[None, ...] # extra axis ensures that they're stacked
                 else:
-                    data_dict['parameters'] = parameters
+                    data_dict['parameters'] = parameters[None, ...] # just as above
                 append_to_h5(filepath, data_dict, opt_options)
-            if opt_options['plot'] and epoch % opt_options['plot_period'] == 0:
+                last_saved_epoch = epoch
+
+            if opt_options['plot'] and epoch % opt_options['plot_period'] == 0 and epoch > 0:
                 plotter.update_plots(
                     parameters, costs, model, expects, cost_values_over_epochs, epoch
                 )
-            # early termination
+
+            # Check for early termination
             if not opt_options['ignore_termination']:
                 termination_key = _terminate_early(
                     grads,
@@ -183,10 +195,30 @@ def optimize(
                 )
                 if termination_key != -1:
                     break
+
+            # Update parameters and costs
             previous_parameters = parameters
             prev_total_cost = total_cost
+            
     except KeyboardInterrupt:
         pass
+    
+    # Final batch of save and/or plot
+    if filepath is not None:
+        if opt_options['verbose']:
+            print(f'... saving data; from {last_saved_epoch+1} to {epoch}')
+
+        cost_since_last_saved = jnp.asarray(cost_values_over_epochs)[last_saved_epoch+1:]
+        data_dict = {
+            'cost_values': cost_since_last_saved,
+            'total_cost': jnp.sum(cost_since_last_saved, axis=-1),
+        }
+        if type(parameters) is dict:
+            data_dict = data_dict | parameters
+        else:
+            data_dict['parameters'] = parameters
+        append_to_h5(filepath, data_dict, opt_options)
+    
     if opt_options['plot']:
         plotter.update_plots(
             parameters,

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -202,13 +202,16 @@ def optimize(
             'cost_values': np.array(cost_values_over_epochs[::save_period]),
             'total_costs': np.array(total_cost_over_epochs[::save_period]),
         }
+
+        # Unpack and save parameters. Ignore the first entry (i.e. the initial seed.)
+        # This should make the parameter indices consistent with the cost indices.
         if type(parameters) is dict:
             for key in parameters:
                 data_dict[key] = np.array(
-                    [params[key] for params in parameters_over_epochs[::save_period]]
+                    [params[key] for params in parameters_over_epochs[1::save_period]]
                 )
         else:
-            data_dict['parameters'] = np.array(parameters_over_epochs[::save_period])
+            data_dict['parameters'] = np.array(parameters_over_epochs[1::save_period])
         append_to_h5(filepath, data_dict, opt_options)
 
     # Final plot update

--- a/qontrol/utils/file_io.py
+++ b/qontrol/utils/file_io.py
@@ -51,3 +51,5 @@ def append_to_h5(filepath: str, data_dict: dict, param_dict: dict) -> None:
         for key, val in param_dict.items():
             try:
                 f.attrs[key] = val
+            except TypeError:
+                f.attrs[key] = str(val)

--- a/qontrol/utils/file_io.py
+++ b/qontrol/utils/file_io.py
@@ -39,15 +39,15 @@ def extract_info_from_h5(filepath: str) -> [dict, dict]:
 def append_to_h5(filepath: str, data_dict: dict, param_dict: dict) -> None:
     with h5py.File(filepath, 'a') as f:
         for key, val in data_dict.items():
+            if val.shape[0] == 0: # takes care of an edge case
+                continue
             if key not in f:
                 f.create_dataset(
-                    key, data=[val], chunks=True, maxshape=(None, *val.shape)
+                    key, data=val, chunks=True, maxshape=(None, *val.shape[1:])
                 )
             else:
-                f[key].resize(f[key].shape[0] + 1, axis=0)
-                f[key][-1] = val
+                f[key].resize(f[key].shape[0] + val.shape[0], axis=0)
+                f[key][-val.shape[0]:] = val
         for key, val in param_dict.items():
             try:
                 f.attrs[key] = val
-            except TypeError:
-                f.attrs[key] = str(val)

--- a/qontrol/utils/file_io.py
+++ b/qontrol/utils/file_io.py
@@ -39,15 +39,13 @@ def extract_info_from_h5(filepath: str) -> [dict, dict]:
 def append_to_h5(filepath: str, data_dict: dict, param_dict: dict) -> None:
     with h5py.File(filepath, 'a') as f:
         for key, val in data_dict.items():
-            if val.shape[0] == 0: # takes care of an edge case
-                continue
             if key not in f:
                 f.create_dataset(
-                    key, data=val, chunks=True, maxshape=(None, *val.shape[1:])
+                    key, data=[val], chunks=True, maxshape=(None, *val.shape)
                 )
             else:
-                f[key].resize(f[key].shape[0] + val.shape[0], axis=0)
-                f[key][-val.shape[0]:] = val
+                f[key].resize(f[key].shape[0] + 1, axis=0)
+                f[key][-1] = val
         for key, val in param_dict.items():
             try:
                 f.attrs[key] = val

--- a/qontrol/utils/file_io.py
+++ b/qontrol/utils/file_io.py
@@ -5,6 +5,7 @@ import os
 import re
 
 import h5py
+import numpy as np
 
 
 def generate_file_path(extension: str, file_name: str, path: str) -> str:
@@ -39,13 +40,15 @@ def extract_info_from_h5(filepath: str) -> [dict, dict]:
 def append_to_h5(filepath: str, data_dict: dict, param_dict: dict) -> None:
     with h5py.File(filepath, 'a') as f:
         for key, val in data_dict.items():
+            _val = np.asarray(val)
             if key not in f:
                 f.create_dataset(
-                    key, data=[val], chunks=True, maxshape=(None, *val.shape)
+                    key, data=_val, chunks=True, maxshape=(None, *_val.shape[1:])
                 )
             else:
-                f[key].resize(f[key].shape[0] + 1, axis=0)
-                f[key][-1] = val
+                prev_dim = f[key].shape[0]
+                f[key].resize(prev_dim + _val.shape[0], axis=0)
+                f[key][prev_dim:] = _val
         for key, val in param_dict.items():
             try:
                 f.attrs[key] = val

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -119,7 +119,7 @@ def test_costs(infid_cost, opt_type, cost, nH, tmp_path):
         dq_options=dq_options,
     )
     opt_result, opt_H = model(opt_params, Tsit5(), None, dq_options)
-    cost_values, terminate = zip(*costs(opt_result, opt_H, opt_params), strict=True)
+    _, terminate = zip(*costs(opt_result, opt_H, opt_params), strict=True)
     assert all(terminate)
 
 
@@ -143,7 +143,7 @@ def test_reinitialize(tmp_path):
     data_dict, _ = extract_info_from_h5(filepath)
     opt_params = {'dp': data_dict['dp'][-1]}
     opt_result, opt_H = model(opt_params, Tsit5(), None, dq_options)
-    cost_values, terminate = zip(*costs(opt_result, opt_H, opt_params), strict=True)
+    _, terminate = zip(*costs(opt_result, opt_H, opt_params), strict=True)
     assert all(terminate)
 
 
@@ -325,7 +325,7 @@ def setup_coherent_system():
 @pytest.mark.parametrize('learning_rate', [1e-4])
 @pytest.mark.parametrize('target_cost', [1e-2])
 def test_gate_plot(learning_rate, target_cost, tmp_path):
-    H_pwc, tsave, init_drive_params, target_gate, Zt = setup_gate_system()
+    H_pwc, tsave, init_drive_params, target_gate, _Zt = setup_gate_system()
 
     model = sepropagator_model(H_pwc, tsave)
     cost = propagator_infidelity(target_unitary=target_gate, target_cost=target_cost)
@@ -377,5 +377,5 @@ def test_single_target_coherent(learning_rate, target_cost, tmp_path):
     )
 
     opt_result, opt_H = model(opt_params, dq.integrators.Expm(), None, dq_options)
-    cost_values, terminate = zip(*cost(opt_result, opt_H, opt_params), strict=True)
+    _, terminate = zip(*cost(opt_result, opt_H, opt_params), strict=True)
     assert all(terminate)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -2,11 +2,16 @@ import diffrax as dx
 import dynamiqs as dq
 import jax.numpy as jnp
 import jax.random
+import matplotlib
+import numpy as np
 import optax
 import pytest
 from dynamiqs.method import Expm, Tsit5
 from jax import Array
 from scipy.stats import unitary_group
+
+
+matplotlib.use('Agg')
 
 from qontrol import (
     coherent_infidelity,
@@ -25,8 +30,8 @@ from qontrol import (
 from qontrol.cost import SummedCost
 
 
-def _filepath(path):
-    d = path / 'sub'
+def _filepath(path, suffix: str = ''):
+    d = path / f'sub{suffix}'
     d.mkdir()
     return d / 'tmp.h5py'
 
@@ -126,7 +131,7 @@ def test_reinitialize(tmp_path):
     model = sesolve_model(H_func, psi0, tsave)
     costs = coherent_infidelity(target_states, target_cost=0.01)
     optimizer = optax.adam(0.0001, b1=0.99, b2=0.99)
-    opt_params = optimize(
+    optimize(
         init_drive_params,
         costs,
         model,
@@ -136,9 +141,40 @@ def test_reinitialize(tmp_path):
         dq_options=dq_options,
     )
     data_dict, _ = extract_info_from_h5(filepath)
+    opt_params = {'dp': data_dict['dp'][-1]}
     opt_result, opt_H = model(opt_params, Tsit5(), None, dq_options)
     cost_values, terminate = zip(*costs(opt_result, opt_H, opt_params), strict=True)
     assert all(terminate)
+
+
+def test_save_period(tmp_path):
+    filepath_1 = _filepath(tmp_path, suffix='1')
+    optimizer_options_1 = {'epochs': 4000, 'plot': False, 'save_period': 1}
+    data_1 = _setup_and_run(filepath_1, optimizer_options_1)
+    filepath_21 = _filepath(tmp_path, suffix='21')
+    optimizer_options_21 = {'epochs': 4000, 'plot': False, 'save_period': 21}
+    data_21 = _setup_and_run(filepath_21, optimizer_options_21)
+    for key, val_1 in data_1.items():
+        assert np.allclose(val_1, data_21[key])
+
+
+def _setup_and_run(filepath: str, opt_options: dict):
+    H_func, tsave, psi0, init_drive_params, target_states = setup_Kerr_osc()
+    dq_options = dq.Options(progress_meter=None)
+    model = sesolve_model(H_func, psi0, tsave)
+    costs = coherent_infidelity(target_states, target_cost=0.01)
+    optimizer = optax.adam(0.0001, b1=0.99, b2=0.99)
+    optimize(
+        init_drive_params,
+        costs,
+        model,
+        filepath=filepath,
+        optimizer=optimizer,
+        opt_options=opt_options,
+        dq_options=dq_options,
+    )
+    data_dict, _ = extract_info_from_h5(filepath)
+    return data_dict
 
 
 @pytest.mark.parametrize('opt_type', ['sepropagator', 'mepropagator'])


### PR DESCRIPTION
Instead of updating the h5 file at every epoch, which was quite slow (especially on an HPC cluster), I introduced a `save_period` option to batch saving. 
      - This necessitated some change in `file_io.py`, but I made sure that the final output was the same as before. 
      - The only change is that `parameters` are not saved at every epoch. I assumed that this would be overkill for most use cases anyway. Now, `parameters` are only stored after every `save_period`. 