### PR TITLE
Prettify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ opt_params = ql.optimize(
     dq_options=dq_options,
 )
 ```
-You should see the following oputput, tracking the cost function values, pulse, pulse fft and expectation 
+You should see the following output, tracking the cost function values, pulse, pulse fft and expectation 
 values over the course of the optimization 
 ![Alt Text](kerr_gif.gif)
 We initialize the `sesolve_model` which when called with `parameters` as input runs `sesolve`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,79 @@
+# Contributing to `qontrol`
+
+We welcome your contribution, whether it be additional cost functions, new functionality, better documentation, etc.
+
+## Requirements
+
+The project was written using Python 3.10+, you must have a compatible version of Python (i.e. >= 3.10) installed on your computer.
+
+## Setup
+
+Clone the repository:
+
+```shell
+git clone https://github.com/dkweiss31/qontrol.git
+cd qontrol
+```
+
+It is good practice to use a virtual environment to install the dependencies, such as conda. Once this environment has been activated, you can run 
+
+```shell
+pip install -e .
+```
+
+to install the package and its dependencies. As a developer you also need to install the developer dependencies:
+
+```shell
+pip install -e ".[dev]"
+```
+
+## Code style
+
+This project follows PEP8 and uses automatic formatting and linting tools to ensure that the code is compliant.
+
+## Workflow
+
+### Before submitting a pull request (run all tasks)
+
+Run all tasks before each commit:
+
+```shell
+task all
+```
+
+### Build the documentation
+
+The documentation is built using [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. MkDocs generates a static website based on the markdown files in the `docs/` directory.
+
+To preview the changes to the documentation as you edit the docstrings or the markdown files in `docs/`, we recommend starting a live preview server, which will automatically rebuild the website upon modifications:
+
+```shell
+task docserve
+```
+
+Open <http://localhost:8000/> in your web browser to preview the documentation website.
+
+You can build the static documentation website locally with:
+
+```shell
+task docbuild
+```
+
+This will create a `site/` directory with the contents of the documentation website. You can then simply open `site/index.html` in your web browser to view the documentation website.
+
+### Run specific tasks
+
+You can also execute tasks individually:
+
+```shell
+> task --list
+lint         lint the code (ruff)
+format       auto-format the code (ruff)
+codespell    check for misspellings (codespell)
+clean        clean the code (ruff + codespell)
+test         run the unit tests suite (pytest)
+docbuild     build the documentation website
+docserve     preview documentation website with hot-reloading
+all          run all tasks before a commit (ruff + codespell + pytest)
+ci           run all the CI checks
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Getting started
+# Qontrol
 
 qontrol is a quantum optimal control package built on top of [dynamiqs](https://github.com/dynamiqs/dynamiqs). You can define your controls however you would in [dynamiqs](https://github.com/dynamiqs/dynamiqs), specifying only how to update the Hamiltonian at each optimizer step. [dynamiqs](https://github.com/dynamiqs/dynamiqs) also has strong native support for batching, which qontrol can leverage e.g. for randomizing over uncertain parameters.
 
@@ -67,7 +67,7 @@ opt_params = ql.optimize(
     dq_options=dq_options,
 )
 ```
-You should see the following oputput, tracking the cost function values, pulse, pulse fft and expectation 
+You should see the following output, tracking the cost function values, pulse, pulse fft and expectation 
 values over the course of the optimization 
 ![Alt Text](kerr_gif.gif)
 We initialize the `sesolve_model` which when called with `parameters` as input runs `sesolve`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,12 @@ edit_uri: ""
 theme:
     name: material
     features:
+        - navigation.tabs # Tabs on top
         - navigation.sections  # Sections are included in the navigation on the left.
+        - navigation.indexes # Allow documents to directly attach to sections
+        - navigation.top # Back-to-top button
         - toc.integrate  # Table of contents is integrated on the left; does not appear separately on the right.
+        - content.code.copy # Copy button in code blocks
     palette:
         - scheme: default
           primary: deep purple
@@ -57,18 +61,28 @@ plugins:
             python:
                 options:
                     show_source: false
+                    show_root_heading: false 
+                    show_root_toc_entry: false # Removes duplicate labels
+                    show_root_full_path: false # Removes python path e.g. script.function()
                     show_if_no_docstring: false
+                    show_labels: false # Declutter labels of class attributes
+                    docstring_style : 'google'
+                    docstring_section_style: list 
                     show_signature_annotations: true
                     members_order: source
+                    separate_signature: false # Same as before, but could be enabled to show multiline functions
+                    line_length: 88
                     heading_level: 4
                     inherited_members: true
-
+                    show_bases: false
+                    merge_init_into_class: true # Declutter by merging the __init__ method defn.
+                    show_symbol_type_heading : true
 nav:
-    - 'index.md'
-    - FAQ:
-        - 'FAQ.md'
-    - API:
-        - 'api.md'
+    - Getting Started: index.md
     - Examples:
-        - Qubit: 'examples/qubit.ipynb'
-        - Kerr Oscillator: 'examples/Kerr_oscillator.ipynb'
+        - Qubit: examples/qubit.ipynb
+        - Kerr Oscillator: examples/Kerr_oscillator.ipynb
+    - API: api.md
+    - Misc: 
+        - FAQ: FAQ.md
+        - Contributing: contributing.md

--- a/qontrol/cost.py
+++ b/qontrol/cost.py
@@ -24,21 +24,20 @@ def incoherent_infidelity(
     where the states at the end of the pulse are $|\psi_{i}^{k}(T)\rangle$ and the
     target states are $|\psi_{t}^{k}\rangle$.
 
-    Args:
-        target_states _(qarray_like of shape (s, n, 1) or (s, n, n))_: target states for
-            the initial states passed to `optimize`. If performing master-equation
-            optimization, the target states should be passed as a list of density matrices.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
-            functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
+    Parameters:
+        target_states: _Shape of QArrays = (s, n, 1) or (s, n, n)_. Target states for the initial states 
+            passed to `optimize`. If performing master-equation optimization, the target states 
+            should be passed as a list of density matrices.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        _(IncoherentInfidelity)_: Callable object that returns the incoherent infidelity
-            and whether the infidelity is below the target value.
-    """  # noqa: E501
+        Callable object that returns the incoherent infidelity and whether the infidelity is below  
+            the target value.
+    """
     return IncoherentInfidelity(cost_multiplier, target_cost, asqarray(target_states))
 
 
@@ -56,21 +55,21 @@ def coherent_infidelity(
     where the states at the end of the pulse are $|\psi_{i}^{k}(T)\rangle$ and the
     target states are $|\psi_{t}^{k}\rangle$.
 
-    Args:
-        target_states _(qarray_like of shape (s, n, 1) or (s, n, n))_: target states for
+    Parameters:
+        target_states: _Shape = (s, n, 1) or (s, n, n)_. Target states for
             the initial states passed to `optimize`. If performing master-equation
             optimization, the target states should be passed as a list of density matrices.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
+        cost_multiplier: Weight for this cost function relative to other cost
             functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
+        target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        _(CoherentInfidelity)_: Callable object that returns the coherent infidelity
-            and whether the infidelity is below the target value.
-    """  # noqa: E501
+        Callable object that returns the coherent infidelity and whether the infidelity is below 
+            the target value.
+    """
     return CoherentInfidelity(cost_multiplier, target_cost, asqarray(target_states))
 
 
@@ -86,19 +85,18 @@ def propagator_infidelity(
     where the propagator at the end of the pulse is $U$, the dimension of the system is
     $d$ and the target unitary $U_{t}$.
 
-    Args:
-        target_unitary _(qarray_like of shape (n, n))_: target unitary for
-            the initial states passed to `optimize`.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
+    Parameters:
+        target_unitary: _Shape = (n,n)_. Target unitary for the initial states passed to `optimize`.
+        cost_multiplier: Weight for this cost function relative to other cost
             functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
+        target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        _(PropagatorInfidelity)_: Callable object that returns the propagator infidelity
-            and whether the infidelity is below the target value.
+        Callable object that returns the propagator infidelity and whether the infidelity is below 
+            the target value.
     """
     target_unitary = asqarray(target_unitary)
     dim = jnp.prod(jnp.array(target_unitary.dims))
@@ -120,27 +118,25 @@ def forbidden_states(
     $t$ and |\psi_{f}^{k}\rangle is a forbidden state for the $k^{\rm th}$ initial
     state.
 
-    Args:
-        forbidden_states_list _(list of list of qarray-like of shape (n, 1) or (n, n))_:
-            For each initial state indexed by s (outer list), a list of forbidden states
-            (inner list) should be provided. The inner lists need not all be of the same shape,
-            for instance if some initial states have more forbidden states than others. The array
-            is eventually reshaped to have shape (s, 1, f, n, 1) or (s, 1, f, n, n) (for
-            `sesolve` or `mesolve`, respectively) where s is the number of initial
-            states, f is the length of the longest forbidden-state list (with
-            zero-padding for meaningless entries) and 1 is an added batch dimension for
-            eventually batching over tsave.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
-            functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
-            is True, the optimization terminates early if all cost functions fall below
-            their target values. If options.all_costs is False, the optimization
-            terminates if only one cost function falls below its target value.
+    Parameters:
+        forbidden_states_list: Shape of QArrays = (n, 1) or (n, n)_. 
+            A list of forbidden states for each initial state (indexed by s). The inner lists need 
+            not all be of the same shape, for instance if some initial states have more forbidden 
+            states than others. The array is eventually reshaped to have shape (s, 1, f, n, 1) or 
+            (s, 1, f, n, n) (for `sesolve` or `mesolve`, respectively) where s is the number of 
+            initial states, f is the length of the longest forbidden-state list (with zero-padding 
+            for meaningless entries) and 1 is an added batch dimension for eventually batching over 
+            tsave.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_cost: Target value for this cost function. If options.all_costs is True, 
+            the optimization terminates early if all cost functions fall below their target values. 
+            If options.all_costs is False, the optimization terminates if only one cost function 
+            falls below its target value.
 
     Returns:
-        _(ForbiddenStates)_: Callable object that returns the forbidden-state cost
-            and whether the cost is below the target value.
-    """  # noqa: E501
+        Callable object that returns the forbidden-state cost and whether the cost is below the 
+            target value.
+    """
     state_shape = forbidden_states_list[0][0].shape
     num_states = len(forbidden_states_list)  # should be the number of initial states
     num_forbid_per_state = jnp.asarray(
@@ -175,17 +171,17 @@ def control_area(
     $$
     where the $\Omega_{j}$ are the individual controls and $T$ is the pulse time.
 
-    Args:
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
-            functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
-            is True, the optimization terminates early if all cost functions fall below
-            their target values. If options.all_costs is False, the optimization
-            terminates if only one cost function falls below its target value.
+    Parameters:
+        threshold: Threshold to use for penalizing areas above this value in absolute magnitude.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_cost: Target value for this cost function. If options.all_costs is True, the 
+            optimization terminates early if all cost functions fall below their target values. If 
+            options.all_costs is False, the optimization terminates if only one cost function falls 
+            below its target value.
 
     Returns:
-        _(ControlArea)_: Callable object that returns the control-area cost
-            and whether the cost is below the target value.
+        Callable object that returns the control-area cost and whether the cost is below the target 
+            value.
     """
     return ControlCostArea(cost_multiplier, target_cost, threshold)
 
@@ -202,19 +198,18 @@ def control_norm(
     where the $\Omega_{j}$ are the individual controls, $T$ is the pulse time
     and $\Omega_{max}$ is the threshold.
 
-    Args:
-        threshold _(float)_: Threshold to use for penalizing amplitudes above this value
-            in absolute magnitude.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
-            functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
-            is True, the optimization terminates early if all cost functions fall below
-            their target values. If options.all_costs is False, the optimization
-            terminates if only one cost function falls below its target value.
+    Parameters:
+        threshold: Threshold to use for penalizing amplitudes above this value in absolute
+            magnitude.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_cost: Target value for this cost function. If options.all_costs is True, the 
+            optimization terminates early if all cost functions fall below their target values. If 
+            options.all_costs is False, the optimization terminates if only one cost function falls 
+            below its target value.
 
     Returns:
-        _(ControlNorm)_: Callable object that returns the control-norm cost
-            and whether the cost is below the target value.
+        Callable object that returns the control-norm cost and whether the cost is below the target 
+            value.
     """
     return ControlCostNorm(cost_multiplier, target_cost, threshold)
 
@@ -229,20 +224,19 @@ def custom_control_cost(
         C = \sum_{j}\int_{0}^{T}F(\Omega_{j}(t))dt,
     $$
 
-    Args:
-        cost_fun _(callable)_: Cost function which must have signature `(control_amp: Array) -> Array`.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
-            functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
-            is True, the optimization terminates early if all cost functions fall below
-            their target values. If options.all_costs is False, the optimization
-            terminates if only one cost function falls below its target value.
+    Parameters:
+        cost_fun: Cost function which must have signature `(control_amp: Array) -> Array`.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_cost: Target value for this cost function. If options.all_costs is True, the 
+            optimization terminates early if all cost functions fall below their target values. If 
+            options.all_costs is False, the optimization terminates if only one cost function falls 
+            below its target value.
 
     Returns:
-        _(CustomCost)_: Callable object that returns the cost for the custom function
-            and whether the cost is below the target value.
+        Callable object that returns the cost for the custom function and whether the cost is below 
+            the target value.
 
-    Examples:
+    ??? example "Example: Penalize negative drive amplitudes"
         ```python
         def penalize_negative(control_amp: jax.Array) -> jax.Array:
             return jax.nn.relu(-control_amp)
@@ -250,8 +244,7 @@ def custom_control_cost(
 
         negative_amp_cost = ql.custom_control_cost(penalize_negative)
         ```
-        In this example, we penalize negative drive amplitudes.
-    """  # noqa: E501
+    """
     cost_fun = jtu.Partial(cost_fun)
     return CustomControlCost(cost_multiplier, target_cost, cost_fun)
 
@@ -265,19 +258,19 @@ def custom_cost(
     optimization that is not included in the hardcoded set of available cost functions.
 
     Args:
-        cost_fun _(callable)_: Cost function which must have signature
+        cost_fun: Cost function which must have signature
             `(result: dq.SolveResult, H: dq.TimeQArray, parameters: dict | Array) -> Array`.
-        cost_multiplier _(float)_: Weight for this cost function relative to other cost
+        cost_multiplier: Weight for this cost function relative to other cost
             functions.
-        target_cost _(float)_: Target value for this cost function. If options.all_costs
+        target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        _(CustomCost)_: Callable object that returns the cost for the custom function.
+        Callable object that returns the cost for the custom function.
 
-    Examples:
+    ??? example "Example: Penalize an expectation value"
         Let's imagine we want to penalize the value of some expectation value at the final
         time in `tsave`.
 
@@ -295,7 +288,7 @@ def custom_cost(
         thing happening under the hood is that the `penalize_expect` function is passed
         to `jax.tree_util.Partial` to enable it to be passed through jitted functions
         without issue.
-    """  # noqa: E501
+    """
     cost_fun = jtu.Partial(cost_fun)
     return CustomCost(cost_multiplier, target_cost, cost_fun)
 

--- a/qontrol/cost.py
+++ b/qontrol/cost.py
@@ -25,18 +25,20 @@ def incoherent_infidelity(
     target states are $|\psi_{t}^{k}\rangle$.
 
     Parameters:
-        target_states: _Shape of QArrays = (s, n, 1) or (s, n, n)_. Target states for the initial states 
-            passed to `optimize`. If performing master-equation optimization, the target states 
-            should be passed as a list of density matrices.
-        cost_multiplier: Weight for this cost function relative to other cost functions.
+        target_states: _Shape of QArrays = (s, n, 1) or (s, n, n)_. Target states for
+            the initial states passed to `optimize`. If performing master-equation
+            optimization, the target states should be passed as a list of density
+            matrices.
+        cost_multiplier: Weight for this cost function relative to other cost
+            functions.
         target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the incoherent infidelity and whether the infidelity is below  
-            the target value.
+        Callable object that returns the incoherent infidelity and whether the
+            infidelity is below the target value.
     """
     return IncoherentInfidelity(cost_multiplier, target_cost, asqarray(target_states))
 
@@ -58,17 +60,17 @@ def coherent_infidelity(
     Parameters:
         target_states: _Shape = (s, n, 1) or (s, n, n)_. Target states for
             the initial states passed to `optimize`. If performing master-equation
-            optimization, the target states should be passed as a list of density matrices.
-        cost_multiplier: Weight for this cost function relative to other cost
-            functions.
+            optimization, the target states should be passed as a list of density
+            matrices.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
         target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
             terminates if only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the coherent infidelity and whether the infidelity is below 
-            the target value.
+        Callable object that returns the coherent infidelity and whether the infidelity
+            is below the target value.
     """
     return CoherentInfidelity(cost_multiplier, target_cost, asqarray(target_states))
 
@@ -86,7 +88,8 @@ def propagator_infidelity(
     $d$ and the target unitary $U_{t}$.
 
     Parameters:
-        target_unitary: _Shape = (n,n)_. Target unitary for the initial states passed to `optimize`.
+        target_unitary: _Shape = (n,n)_. Target unitary for the initial states passed
+            to `optimize`.
         cost_multiplier: Weight for this cost function relative to other cost
             functions.
         target_cost: Target value for this cost function. If options.all_costs
@@ -95,8 +98,8 @@ def propagator_infidelity(
             terminates if only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the propagator infidelity and whether the infidelity is below 
-            the target value.
+        Callable object that returns the propagator infidelity and whether the
+            infidelity is below the target value.
     """
     target_unitary = asqarray(target_unitary)
     dim = jnp.prod(jnp.array(target_unitary.dims))
@@ -112,30 +115,30 @@ def forbidden_states(
 
     This cost function is defined as
     $$
-        C = \sum_{k}\sum_{f}\int_{0}^{T}dt|\langle\psi_{f}^{k}|\psi_{i}^{k}(t)\rangle|^2,
+        C=\sum_{k}\sum_{f}\int_{0}^{T}dt|\langle\psi_{f}^{k}|\psi_{i}^{k}(t)\rangle|^2,
     $$
     where $|\psi_{i}^{k}(t)\rangle$ is the $k^{\rm th}$ initial state propagated to time
     $t$ and |\psi_{f}^{k}\rangle is a forbidden state for the $k^{\rm th}$ initial
     state.
 
     Parameters:
-        forbidden_states_list: Shape of QArrays = (n, 1) or (n, n)_. 
-            A list of forbidden states for each initial state (indexed by s). The inner lists need 
-            not all be of the same shape, for instance if some initial states have more forbidden 
-            states than others. The array is eventually reshaped to have shape (s, 1, f, n, 1) or 
-            (s, 1, f, n, n) (for `sesolve` or `mesolve`, respectively) where s is the number of 
-            initial states, f is the length of the longest forbidden-state list (with zero-padding 
-            for meaningless entries) and 1 is an added batch dimension for eventually batching over 
-            tsave.
+        forbidden_states_list: Shape of QArrays = (n, 1) or (n, n)_.
+            A list of forbidden states for each initial state (indexed by s). The inner
+            lists need not all be of the same shape, for instance if some initial states
+            have more forbidden states than others. The array is eventually reshaped to
+            have shape (s, 1, f, n, 1) or (s, 1, f, n, n) (for `sesolve` or `mesolve`,
+            respectively) where s is the number of initial states, f is the length of
+            the longest forbidden-state list (with zero-padding for meaningless entries)
+            and 1 is an added batch dimension for eventually batching over tsave.
         cost_multiplier: Weight for this cost function relative to other cost functions.
-        target_cost: Target value for this cost function. If options.all_costs is True, 
-            the optimization terminates early if all cost functions fall below their target values. 
-            If options.all_costs is False, the optimization terminates if only one cost function 
-            falls below its target value.
+        target_cost: Target value for this cost function. If options.all_costs is True,
+            the optimization terminates early if all cost functions fall below their
+            target values. If options.all_costs is False, the optimization terminates if
+            only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the forbidden-state cost and whether the cost is below the 
-            target value.
+        Callable object that returns the forbidden-state cost and whether the cost is
+            below the target value.
     """
     state_shape = forbidden_states_list[0][0].shape
     num_states = len(forbidden_states_list)  # should be the number of initial states
@@ -172,16 +175,17 @@ def control_area(
     where the $\Omega_{j}$ are the individual controls and $T$ is the pulse time.
 
     Parameters:
-        threshold: Threshold to use for penalizing areas above this value in absolute magnitude.
+        threshold: Threshold to use for penalizing areas above this value in absolute
+            magnitude.
         cost_multiplier: Weight for this cost function relative to other cost functions.
-        target_cost: Target value for this cost function. If options.all_costs is True, the 
-            optimization terminates early if all cost functions fall below their target values. If 
-            options.all_costs is False, the optimization terminates if only one cost function falls 
-            below its target value.
+        target_cost: Target value for this cost function. If options.all_costs is True,
+            the optimization terminates early if all cost functions fall below their
+            target values. If options.all_costs is False, the optimization terminates
+            if only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the control-area cost and whether the cost is below the target 
-            value.
+        Callable object that returns the control-area cost and whether the cost is
+            below the target value.
     """
     return ControlCostArea(cost_multiplier, target_cost, threshold)
 
@@ -199,17 +203,17 @@ def control_norm(
     and $\Omega_{max}$ is the threshold.
 
     Parameters:
-        threshold: Threshold to use for penalizing amplitudes above this value in absolute
-            magnitude.
+        threshold: Threshold to use for penalizing amplitudes above this value in
+            absolute magnitude.
         cost_multiplier: Weight for this cost function relative to other cost functions.
-        target_cost: Target value for this cost function. If options.all_costs is True, the 
-            optimization terminates early if all cost functions fall below their target values. If 
-            options.all_costs is False, the optimization terminates if only one cost function falls 
-            below its target value.
+        target_cost: Target value for this cost function. If options.all_costs is True,
+            the optimization terminates early if all cost functions fall below their
+            target values. If options.all_costs is False, the optimization terminates
+            if only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the control-norm cost and whether the cost is below the target 
-            value.
+        Callable object that returns the control-norm cost and whether the cost is
+            below the target value.
     """
     return ControlCostNorm(cost_multiplier, target_cost, threshold)
 
@@ -225,16 +229,17 @@ def custom_control_cost(
     $$
 
     Parameters:
-        cost_fun: Cost function which must have signature `(control_amp: Array) -> Array`.
+        cost_fun: Cost function which must have signature `(control_amp: Array) ->
+            Array`.
         cost_multiplier: Weight for this cost function relative to other cost functions.
-        target_cost: Target value for this cost function. If options.all_costs is True, the 
-            optimization terminates early if all cost functions fall below their target values. If 
-            options.all_costs is False, the optimization terminates if only one cost function falls 
-            below its target value.
+        target_cost: Target value for this cost function. If options.all_costs is True,
+            the optimization terminates early if all cost functions fall below their
+            target values. If options.all_costs is False, the optimization terminates if
+            only one cost function falls below its target value.
 
     Returns:
-        Callable object that returns the cost for the custom function and whether the cost is below 
-            the target value.
+        Callable object that returns the cost for the custom function and whether the
+            cost is below the target value.
 
     ??? example "Example: Penalize negative drive amplitudes"
         ```python
@@ -259,9 +264,9 @@ def custom_cost(
 
     Args:
         cost_fun: Cost function which must have signature
-            `(result: dq.SolveResult, H: dq.TimeQArray, parameters: dict | Array) -> Array`.
-        cost_multiplier: Weight for this cost function relative to other cost
-            functions.
+            `(result: dq.SolveResult, H: dq.TimeQArray, parameters: dict | Array) ->
+            Array`.
+        cost_multiplier: Weight for this cost function relative to other cost functions.
         target_cost: Target value for this cost function. If options.all_costs
             is True, the optimization terminates early if all cost functions fall below
             their target values. If options.all_costs is False, the optimization
@@ -271,8 +276,8 @@ def custom_cost(
         Callable object that returns the cost for the custom function.
 
     ??? example "Example: Penalize an expectation value"
-        Let's imagine we want to penalize the value of some expectation value at the final
-        time in `tsave`.
+        Let's imagine we want to penalize the value of some expectation value at the
+        final time in `tsave`.
 
         ```python
         def penalize_expect(

--- a/qontrol/model.py
+++ b/qontrol/model.py
@@ -20,28 +20,24 @@ def sesolve_model(
 ) -> SESolveModel:
     r"""Instantiate sesolve model.
 
-    Here we instantiate the model that is called at each step of the optimization
-    iteration, returning a tuple of the result of calling `sesolve` as well as the
-    Hamiltonian evaluated at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization iteration, 
+    returning a tuple of the result of calling `sesolve` as well as the Hamiltonian evaluated at 
+    the parameter values.
 
-    Args:
-        H_function _(callable)_: function specifying how to update the Hamiltonian
-        psi0 _(QArrayLike of shape (..., n, 1))_: Initial states.
-        tsave_or_function _(ArrayLike of shape (ntsave,) or callable)_: Either an
-            array of times passed to sesolve or a method specifying how to update
-            the times that are passed to sesolve
-        exp_ops _(list of array-like)_: Operators to calculate expectation values of,
-            in case some of the cost functions depend on the value of certain
-            expectation values.
+    Parameters:
+        H_function: function specifying how to update the Hamiltonian
+        psi0: _Shape = (..., n, 1)_. Initial states.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
+            to `sesolve` or a method specifying how to update the times that are passed to 
+            `sesolve`.
+        exp_ops: Operators to calculate expectation values of, in case some of the cost functions 
+            depend on the value of certain expectation values.
 
     Returns:
-        _(SESolveModel)_: Model that when called with the parameters we optimize
-            over as argument returns the results of `sesolve` as well as the updated
-            Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns the results 
+            of `sesolve` as well as the updated Hamiltonian
 
-    Examples:
-        In this simple example the parameters are the amplitudes of piecewise-constant
-        controls
+    ??? example "Basic example: Piecewise-constant control"
         ```python
         tsave = jnp.linspace(0.0, 11.0, 10)
         psi0 = [dq.basis(2, 0)]
@@ -59,6 +55,7 @@ def sesolve_model(
         ```
         See for example [this tutorial](../examples/qubit).
 
+    ??? example "Advanced example: Spline control"
         In more complex cases, we can imagine that the optimized parameters
         are the control points fed into a spline, and additionally the control
         times themselves are optimized.
@@ -91,7 +88,7 @@ def sesolve_model(
         ```
         See for example [this tutorial](../examples/Kerr_oscillator#time-optimal-control).
 
-    """  # noqa E501
+    """
     H_function, tsave_or_function = _initialize_model(H_function, tsave_or_function)
     return SESolveModel(
         H_function, tsave_or_function, exp_ops=exp_ops, initial_states=psi0
@@ -108,28 +105,25 @@ def mesolve_model(
 ) -> MESolveModel:
     r"""Instantiate mesolve model.
 
-    Here we instantiate the model that is called at each step of the optimization
-    iteration, returning a tuple of the result of calling `mesolve` as well as the
-    Hamiltonian evaluated at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization iteration, 
+    returning a tuple of the result of calling `mesolve` as well as the Hamiltonian evaluated at 
+    the parameter values.
 
-    Args:
-        H_function _(callable)_: function specifying how to update the Hamiltonian
-        jump_ops _(list of qarray-like or time-qarray, each of shape (...Lk, n, n))_:
-            List of jump operators.
-        rho0 _(QArrayLike of shape (..., n, n))_: Initial density matrices.
-        tsave_or_function _(ArrayLike of shape (ntsave,) or callable)_: Either an
-            array of times passed to sesolve or a method specifying how to update
-            the times that are passed to sesolve
-        exp_ops _(list of array-like)_: Operators to calculate expectation values of,
-            in case some of the cost functions depend on the value of certain
-            expectation values.
+    Parameters:
+        H_function: function specifying how to update the Hamiltonian
+        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of jump 
+            operators.
+        rho0: _Shape = (..., n, n)_. Initial density matrices.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
+            to sesolve or a method specifying how to update the times that are passed to `mesolve`.
+        exp_ops: Operators to calculate expectation values of, in case some of the cost functions 
+            depend on the value of certain expectation values.
 
     Returns:
-        _(MESolveModel)_: Model that when called with the parameters we optimize
-            over as argument returns the results of `mesolve` as well as the updated
-            Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns the results 
+            of `mesolve` as well as the updated Hamiltonian
 
-    Examples:
+    ??? example "Advanced example: Spline control"
         Instantiating a `MESolveModel` is quite similar to instantiating an
         `SESolveModel`, with the two differences being that we need to supply jump
         operators, and the initial and target states should be specified as density
@@ -159,27 +153,21 @@ def sepropagator_model(
 ) -> SEPropagatorModel:
     r"""Instantiate sepropagator model.
 
-    Here we instantiate the model that is called at each step of the optimization
-    iteration, returning a tuple of the result of calling `sepropagator` as well
-    as the Hamiltonian evaluated at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization iteration, 
+    returning a tuple of the result of calling `sepropagator` as well as the Hamiltonian evaluated 
+    at the parameter values.
 
-    Args:
-        H_function _(callable)_: function specifying how to update the Hamiltonian
-        tsave_or_function _(ArrayLike of shape (ntsave,) or callable)_: Either an
-            array of times passed to the method or a function specifying how to update
-            the times that are passed to the method
-        exp_ops _(list of array-like)_: Operators to calculate expectation values of,
-            in case some of the cost functions depend on the value of certain
-            expectation values.
+    Parameters:
+        H_function: function specifying how to update the Hamiltonian
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
+            to `sepropagator` or a method specifying how to update the times that are passed to 
+            `sepropagator`.
 
     Returns:
-        _(SEPropagatorModel)_: Model that when called with the parameters we optimize
-            over as argument returns the results of `sepropagator` as well as the
-            updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns the results 
+            of `sepropagator` as well as the updated Hamiltonian
 
-    Examples:
-        In this simple example the parameters are the amplitudes of piecewise-constant
-        controls
+    ??? example "Basic example: Piecewise-constant control"
         ```python
         tsave = jnp.linspace(0.0, 11.0, 10)
         H1s = [dq.sigmax(), dq.sigmay()]
@@ -195,6 +183,7 @@ def sepropagator_model(
         sepropagator_model = ql.sepropagator_model(H_pwc, tsave)
         ```
 
+    ??? example "Advanced example: Spline control"
         In more complex cases, we can imagine that the optimized parameters
         are the control points fed into a spline, and additionally the control
         times themselves are optimized.
@@ -238,27 +227,23 @@ def mepropagator_model(
 ) -> MEPropagatorModel:
     r"""Instantiate mepropagator model.
 
-    Here we instantiate the model that is called at each step of the optimization
-    iteration, returning a tuple of the result of calling `mepropagator` as well
-    as the Hamiltonian evaluated at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization iteration, 
+    returning a tuple of the result of calling `mepropagator` as well as the Hamiltonian evaluated 
+    at the parameter values.
 
-    Args:
-        H_function _(callable)_: function specifying how to update the Hamiltonian
-        jump_ops _(list of qarray-like or time-qarray, each of shape (...Lk, n, n))_:
-            List of jump operators.
-        tsave_or_function _(ArrayLike of shape (ntsave,) or callable)_: Either an
-            array of times passed to the method or a method specifying how to update
-            the times that are passed to the method
-        exp_ops _(list of array-like)_: Operators to calculate expectation values of,
-            in case some of the cost functions depend on the value of certain
-            expectation values.
+    Parameters:
+        H_function: function specifying how to update the Hamiltonian
+        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of jump 
+            operators.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
+            to `mepropagator` or a method specifying how to update the times that are passed to 
+            `mepropagator`.
 
     Returns:
-        _(MEPropagatorModel)_: Model that when called with the parameters we optimize
-            over as argument returns the results of `mepropagator` as well as the
-            updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns the results 
+            of `mepropagator` as well as the updated Hamiltonian
 
-    Examples:
+    ??? example "Advanced example: Spline control"
         Instantiating a `MEPropagatorModel` is quite similar to instantiating an
         `SEPropagatorModel`, with the difference being that we need to supply jump
         operators. Continuing the last example from `sepropagator_model`
@@ -308,12 +293,6 @@ class PropagatorModel(Model):
 
 
 class SESolveModel(SolveModel):
-    r"""Model for Schrödinger-equation optimization.
-
-    When called with the parameters we optimize over returns the results of `sesolve`
-    as well as the updated Hamiltonian.
-    """
-
     initial_states: QArrayLike
 
     def __call__(
@@ -338,12 +317,6 @@ class SESolveModel(SolveModel):
 
 
 class MESolveModel(SolveModel):
-    r"""Model for Lindblad-master-equation optimization.
-
-    When called with the parameters we optimize over returns the results of `mesolve`
-    as well as the updated Hamiltonian.
-    """
-
     initial_states: QArrayLike
     jump_ops: list[QArrayLike | TimeQArray]
 
@@ -370,12 +343,6 @@ class MESolveModel(SolveModel):
 
 
 class SEPropagatorModel(PropagatorModel):
-    r"""Model for Schrödinger-equation propagator optimization.
-
-    When called with the parameters we optimize over returns the results of
-    `sepropagate` as well as the updated Hamiltonian.
-    """
-
     def __call__(
         self,
         parameters: Array | dict,
@@ -392,12 +359,6 @@ class SEPropagatorModel(PropagatorModel):
 
 
 class MEPropagatorModel(PropagatorModel):
-    r"""Model for Lindblad-master-equation propagator optimization.
-
-    When called with the parameters we optimize over returns the results of `mesolve`
-    as well as the updated Hamiltonian.
-    """
-
     jump_ops: list[QArrayLike | TimeQArray]
 
     def __call__(

--- a/qontrol/model.py
+++ b/qontrol/model.py
@@ -37,7 +37,7 @@ def sesolve_model(
         Model that when called with the parameters we optimize over as argument returns
             the results of `sesolve` as well as the updated Hamiltonian.
 
-    ??? example "Basic example: Piecewise-constant control"
+    ??? example "Piecewise-constant control"
         ```python
         tsave = jnp.linspace(0.0, 11.0, 10)
         psi0 = [dq.basis(2, 0)]
@@ -55,9 +55,9 @@ def sesolve_model(
         ```
         See for example [this tutorial](../examples/qubit).
 
-    ??? example "Advanced example: Spline control"
+    ??? example "Spline control"
         In more complex cases, we can imagine that the optimized parameters
-        are the control points fed into a spline, and additionally the control
+        are the control points fed into a spline, and aditionally the control
         times themselves are optimized.
         ```python
         init_drive_params_topt = {
@@ -106,9 +106,9 @@ def mesolve_model(
 ) -> MESolveModel:
     r"""Instantiate mesolve model.
 
-    Here we instantiate the model that is called at each step of the optimization
-    iteration, returning a tuple of the result of calling `mesolve` as well as the
-    Hamiltonian evaluated at the parameter values.
+    Here we instantiate the model called at each step of the optimization iteration,
+    returning a tuple of the result of calling `mesolve` as well as the Hamiltonian
+    evaluated at the parameter values.
 
     Parameters:
         H_function: function specifying how to update the Hamiltonian
@@ -125,7 +125,7 @@ def mesolve_model(
         Model that when called with the parameters we optimize over as argument returns
             the results of `mesolve` as well as the updated Hamiltonian.
 
-    ??? example "Advanced example: Spline control"
+    ??? example "Instantiating a MESolveModel"
         Instantiating a `MESolveModel` is quite similar to instantiating an
         `SESolveModel`, with the two differences being that we need to supply jump
         operators, and the initial and target states should be specified as density
@@ -169,7 +169,7 @@ def sepropagator_model(
         Model that when called with the parameters we optimize over as argument returns
             the results of `sepropagator` as well as the updated Hamiltonian.
 
-    ??? example "Basic example: Piecewise-constant control"
+    ??? example "Instantiating a `SEPropagatorModel`"
         ```python
         tsave = jnp.linspace(0.0, 11.0, 10)
         H1s = [dq.sigmax(), dq.sigmay()]
@@ -183,38 +183,6 @@ def sepropagator_model(
 
 
         sepropagator_model = ql.sepropagator_model(H_pwc, tsave)
-        ```
-
-    ??? example "Advanced example: Spline control"
-        In more complex cases, we can imagine that the optimized parameters
-        are the control points fed into a spline, and additionally the control
-        times themselves are optimized.
-        ```python
-        init_drive_params_topt = {
-            'dp': -0.001 * jnp.ones((len(H1s), len(tsave))),
-            't': tsave[-1],
-        }
-
-
-        def H_func_topt(t: float, drive_params_dict: dict) -> dq.TimeQArray:
-            drive_params = drive_params_dict['dp']
-            new_tsave = jnp.linspace(0.0, drive_params_dict['t'], len(tsave))
-            drive_spline = _drive_spline(drive_params, envelope, new_tsave)
-            drive_amps = drive_spline.evaluate(t)
-            drive_Hs = jnp.einsum('d,dij->ij', drive_amps, H1s)
-            return H0 + drive_Hs
-
-
-        def update_H_topt(drive_params_dict: dict) -> dq.TimeQArray:
-            new_H = jtu.Partial(H_func_topt, drive_params_dict=drive_params_dict)
-            return dq.timecallable(new_H)
-
-
-        def update_tsave_topt(drive_params_dict: dict) -> jax.Array:
-            return jnp.linspace(0.0, drive_params_dict['t'], len(tsave))
-
-
-        sep_t_opt_Kerr_model = ql.sepropagator_model(update_H_topt, update_tsave_topt)
         ```
 
     """
@@ -245,7 +213,7 @@ def mepropagator_model(
         Model that when called with the parameters we optimize over as argument returns
             the results of `mepropagator` as well as the updated Hamiltonian.
 
-    ??? example "Advanced example: Spline control"
+    ??? example "Instantiating a `MEPropagatorModel`"
         Instantiating a `MEPropagatorModel` is quite similar to instantiating an
         `SEPropagatorModel`, with the difference being that we need to supply jump
         operators. Continuing the last example from `sepropagator_model`

--- a/qontrol/model.py
+++ b/qontrol/model.py
@@ -57,7 +57,7 @@ def sesolve_model(
 
     ??? example "Spline control"
         In more complex cases, we can imagine that the optimized parameters
-        are the control points fed into a spline, and aditionally the control
+        are the control points fed into a spline, and additionally the control
         times themselves are optimized.
         ```python
         init_drive_params_topt = {

--- a/qontrol/model.py
+++ b/qontrol/model.py
@@ -20,22 +20,22 @@ def sesolve_model(
 ) -> SESolveModel:
     r"""Instantiate sesolve model.
 
-    Here we instantiate the model that is called at each step of the optimization iteration, 
-    returning a tuple of the result of calling `sesolve` as well as the Hamiltonian evaluated at 
-    the parameter values.
+    Here we instantiate the model that is called at each step of the optimization
+    iteration, returning a tuple of the result of calling `sesolve` as well as the
+    Hamiltonian evaluated at the parameter values.
 
     Parameters:
         H_function: function specifying how to update the Hamiltonian
         psi0: _Shape = (..., n, 1)_. Initial states.
-        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
-            to `sesolve` or a method specifying how to update the times that are passed to 
-            `sesolve`.
-        exp_ops: Operators to calculate expectation values of, in case some of the cost functions 
-            depend on the value of certain expectation values.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array
+            of times passed to `sesolve` or a method specifying how to update the times
+            that are passed to `sesolve`.
+        exp_ops: Operators to calculate expectation values of, in case some of the cost
+            functions depend on the value of certain expectation values.
 
     Returns:
-        Model that when called with the parameters we optimize over as argument returns the results 
-            of `sesolve` as well as the updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns
+            the results of `sesolve` as well as the updated Hamiltonian.
 
     ??? example "Basic example: Piecewise-constant control"
         ```python
@@ -86,7 +86,8 @@ def sesolve_model(
 
         se_t_opt_Kerr_model = ql.sesolve_model(update_H_topt, psi0, update_tsave_topt)
         ```
-        See for example [this tutorial](../examples/Kerr_oscillator#time-optimal-control).
+        See for example
+        [this tutorial](../examples/Kerr_oscillator#time-optimal-control).
 
     """
     H_function, tsave_or_function = _initialize_model(H_function, tsave_or_function)
@@ -105,23 +106,24 @@ def mesolve_model(
 ) -> MESolveModel:
     r"""Instantiate mesolve model.
 
-    Here we instantiate the model that is called at each step of the optimization iteration, 
-    returning a tuple of the result of calling `mesolve` as well as the Hamiltonian evaluated at 
-    the parameter values.
+    Here we instantiate the model that is called at each step of the optimization
+    iteration, returning a tuple of the result of calling `mesolve` as well as the
+    Hamiltonian evaluated at the parameter values.
 
     Parameters:
         H_function: function specifying how to update the Hamiltonian
-        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of jump 
-            operators.
+        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of
+            jump operators.
         rho0: _Shape = (..., n, n)_. Initial density matrices.
-        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
-            to sesolve or a method specifying how to update the times that are passed to `mesolve`.
-        exp_ops: Operators to calculate expectation values of, in case some of the cost functions 
-            depend on the value of certain expectation values.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of
+            times passed to sesolve or a method specifying how to update the times that
+            are passed to `mesolve`.
+        exp_ops: Operators to calculate expectation values of, in case some of the cost
+            functions depend on the value of certain expectation values.
 
     Returns:
-        Model that when called with the parameters we optimize over as argument returns the results 
-            of `mesolve` as well as the updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns
+            the results of `mesolve` as well as the updated Hamiltonian.
 
     ??? example "Advanced example: Spline control"
         Instantiating a `MESolveModel` is quite similar to instantiating an
@@ -153,19 +155,19 @@ def sepropagator_model(
 ) -> SEPropagatorModel:
     r"""Instantiate sepropagator model.
 
-    Here we instantiate the model that is called at each step of the optimization iteration, 
-    returning a tuple of the result of calling `sepropagator` as well as the Hamiltonian evaluated 
-    at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization
+    iteration, returning a tuple of the result of calling `sepropagator` as well as the
+    Hamiltonian evaluated at the parameter values.
 
     Parameters:
         H_function: function specifying how to update the Hamiltonian
-        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
-            to `sepropagator` or a method specifying how to update the times that are passed to 
-            `sepropagator`.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of
+            times passed to `sepropagator` or a method specifying how to update the
+            times that are passed to `sepropagator`.
 
     Returns:
-        Model that when called with the parameters we optimize over as argument returns the results 
-            of `sepropagator` as well as the updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns
+            the results of `sepropagator` as well as the updated Hamiltonian.
 
     ??? example "Basic example: Piecewise-constant control"
         ```python
@@ -227,21 +229,21 @@ def mepropagator_model(
 ) -> MEPropagatorModel:
     r"""Instantiate mepropagator model.
 
-    Here we instantiate the model that is called at each step of the optimization iteration, 
-    returning a tuple of the result of calling `mepropagator` as well as the Hamiltonian evaluated 
-    at the parameter values.
+    Here we instantiate the model that is called at each step of the optimization
+    iteration, returning a tuple of the result of calling `mepropagator` as well as the
+    Hamiltonian evaluated at the parameter values.
 
     Parameters:
         H_function: function specifying how to update the Hamiltonian
-        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of jump 
-            operators.
-        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of times passed 
-            to `mepropagator` or a method specifying how to update the times that are passed to 
-            `mepropagator`.
+        jump_ops: _Each of QArray or TimeQArray is has shape = (...Lk, n, n))_. List of
+            jump operators.
+        tsave_or_function: _If ArrayLike, then Shape = (ntsave,)_. Either an array of
+            times passed to `mepropagator` or a method specifying how to update the
+            times that are passed to `mepropagator`.
 
     Returns:
-        Model that when called with the parameters we optimize over as argument returns the results 
-            of `mepropagator` as well as the updated Hamiltonian
+        Model that when called with the parameters we optimize over as argument returns
+            the results of `mepropagator` as well as the updated Hamiltonian.
 
     ??? example "Advanced example: Spline control"
         Instantiating a `MEPropagatorModel` is quite similar to instantiating an

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -59,13 +59,13 @@ def optimize(
     r"""Perform gradient descent to optimize Hamiltonian parameters.
 
     This function takes as input `parameters` which parametrize a `model` when called
-    performs time-dynamics simulations using Dynamiqs. How to update `parameters` is encoded
-    in the list of cost functions `costs` that contains e.g. infidelity contributions, pulse
-    amplitude penalties, etc.
+    performs time-dynamics simulations using Dynamiqs. How to update `parameters` is
+    encoded in the list of cost functions `costs` that contains e.g. infidelity
+    contributions, pulse amplitude penalties, etc.
 
     Parameters:
-        parameters: parameters to optimize over that are used to define the Hamiltonian and control 
-            times.
+        parameters: parameters to optimize over that are used to define the Hamiltonian
+            and control times.
         costs: List of cost functions used to perform the optimization.
         model: Model that is called at each iteration step.
         optimizer: optax optimizer to use
@@ -74,33 +74,35 @@ def optimize(
         method: Method passed to Dynamiqs.
         gradient: Gradient passed to Dynamiqs.
         filepath: Filepath of where to save optimization results.
-        dq_options : Options for the Dynamiqs integrator. 
+        dq_options : Options for the Dynamiqs integrator.
         opt_options: Options for grape optimization.
             ??? info "Detailed `opt_options` API"
-                - `verbose` (`bool`, default: `True`): If `True`, the optimizer will print out the 
-                    infidelity at each epoch step to track the progress of the optimization.
-                - `ignore_termination` (`bool`, default: `False`): Whether to ignore the various 
-                    termination conditions
-                - `all_costs` (`bool`, default: `True`): Whether or not all costs must be below 
-                    their targets for early termination of the optimizer. If `False`, the 
-                    optimization terminates if only one cost function is below the target 
-                    (typically infidelity).
+                - `verbose` (`bool`, default: `True`): If `True`, the optimizer will
+                    print out the infidelity at each epoch step to track the progress of
+                    the optimization.
+                - `ignore_termination` (`bool`, default: `False`): Whether to ignore the
+                    various termination conditions
+                - `all_costs` (`bool`, default: `True`): Whether or not all costs must
+                    be below their targets for early termination of the optimizer. If
+                    `False`, the optimization terminates if only one cost function is
+                    below the target (typically infidelity).
                 - `epochs` (`int`, default: `2000`): Number of optimization epochs.
-                - `plot` (`bool`, default: `True`): Whether to plot the results during the 
-                    optimization (for the epochs where results are plotted, necessarily suffer a 
-                    time penalty).
-                - `plot_period` (`int`, default: `30`): If plot is `True`, plot every `plot_period`.
-                - `save_period` (`int`, default: `30`): If a filepath is provided, save every 
-                    `save_period`.
-                - `xtol` (`float`, default: `1e-8`): Terminate the optimization if the parameters 
-                    are not being updated
-                - `ftol` (`float`, default: `1e-8`): Terminate the optimization if the cost 
-                    function is not changing above this level
-                - `gtol` (`float`, default: `1e-8`): Terminate the optimization if the norm of the 
-                    gradient falls below this level
+                - `plot` (`bool`, default: `True`): Whether to plot the results during
+                    the optimization (for the epochs where results are plotted,
+                    necessarily suffer a time penalty).
+                - `plot_period` (`int`, default: `30`): If plot is `True`, plot every
+                    `plot_period`.
+                - `save_period` (`int`, default: `30`): If a filepath is provided, save
+                    every `save_period`.
+                - `xtol` (`float`, default: `1e-8`): Terminate the optimization if the
+                    parameters are not being updated.
+                - `ftol` (`float`, default: `1e-8`): Terminate the optimization if the
+                    cost function is not changing above this level.
+                - `gtol` (`float`, default: `1e-8`): Terminate the optimization if the
+                    norm of the gradient falls below this level.
 
     Returns:
-        Optimized parameters from the final timestep
+        Optimized parameters from the final timestep.
     """
     # Initialize
     opt_options = {**default_options, **(opt_options or {})}

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -59,44 +59,50 @@ def optimize(
     r"""Perform gradient descent to optimize Hamiltonian parameters.
 
     This function takes as input `parameters` which parametrize a `model` when called
-    performs time-dynamics simulations using dynamiqs. How to update `parameters` is encoded
+    performs time-dynamics simulations using Dynamiqs. How to update `parameters` is encoded
     in the list of cost functions `costs` that contains e.g. infidelity contributions, pulse
     amplitude penalties, etc.
 
-    Args:
-        parameters _(dict or array-like)_: parameters to optimize
-            over that are used to define the Hamiltonian and control times.
-        costs _(list of Cost instances)_: List of cost functions used to perform the
-            optimization.
-        model _(Model)_: Model that is called at each iteration step.
-        optimizer _(optax.GradientTransformation)_: optax optimizer to use
+    Parameters:
+        parameters: parameters to optimize over that are used to define the Hamiltonian and control 
+            times.
+        costs: List of cost functions used to perform the optimization.
+        model: Model that is called at each iteration step.
+        optimizer: optax optimizer to use
             for gradient descent. Defaults to the Adam optimizer.
-        plotter _(Plotter)_: Plotter for monitoring the optimization.
-        method _(Method)_: Method passed to dynamiqs.
-        gradient _()Gradient_: Gradient passed to dynamiqs.
-        options _(dict)_: Options for grape optimization.
-            verbose _(bool)_: If `True`, the optimizer will print out the infidelity at
-                each epoch step to track the progress of the optimization.
-            ignore_termination _(bool)_: Whether to ignore the various termination conditions
-            all_costs _(bool)_: Whether or not all costs must be below their targets for
-                early termination of the optimizer. If False, the optimization terminates
-                if only one cost function is below the target (typically infidelity).
-            epochs _(int)_: Number of optimization epochs.
-            plot _(bool)_: Whether to plot the results during the optimization (for the
-                epochs where results are plotted, necessarily suffer a time penalty).
-            plot_period _(int)_: If plot is True, plot every plot_period.
-            xtol _(float)_: Defaults to 1e-8, terminate the optimization if the parameters
-                are not being updated
-            ftol _(float)_: Defaults to 1e-8, terminate the optimization if the cost
-                function is not changing above this level
-            gtol _(float)_: Defaults to 1e-8, terminate the optimization if the norm of the
-                gradient falls below this level
-        filepath _(str)_: Filepath of where to save optimization results.
+        plotter: Plotter for monitoring the optimization.
+        method: Method passed to Dynamiqs.
+        gradient: Gradient passed to Dynamiqs.
+        filepath: Filepath of where to save optimization results.
+        dq_options : Options for the Dynamiqs integrator. 
+        opt_options: Options for grape optimization.
+            ??? info "Detailed `opt_options` API"
+                - `verbose` (`bool`, default: `True`): If `True`, the optimizer will print out the 
+                    infidelity at each epoch step to track the progress of the optimization.
+                - `ignore_termination` (`bool`, default: `False`): Whether to ignore the various 
+                    termination conditions
+                - `all_costs` (`bool`, default: `True`): Whether or not all costs must be below 
+                    their targets for early termination of the optimizer. If `False`, the 
+                    optimization terminates if only one cost function is below the target 
+                    (typically infidelity).
+                - `epochs` (`int`, default: `2000`): Number of optimization epochs.
+                - `plot` (`bool`, default: `True`): Whether to plot the results during the 
+                    optimization (for the epochs where results are plotted, necessarily suffer a 
+                    time penalty).
+                - `plot_period` (`int`, default: `30`): If plot is `True`, plot every `plot_period`.
+                - `save_period` (`int`, default: `30`): If a filepath is provided, save every 
+                    `save_period`.
+                - `xtol` (`float`, default: `1e-8`): Terminate the optimization if the parameters 
+                    are not being updated
+                - `ftol` (`float`, default: `1e-8`): Terminate the optimization if the cost 
+                    function is not changing above this level
+                - `gtol` (`float`, default: `1e-8`): Terminate the optimization if the norm of the 
+                    gradient falls below this level
 
     Returns:
-        optimized parameters from the final timestep
-    """  # noqa E501
-    # initialize
+        Optimized parameters from the final timestep
+    """
+    # Initialize
     opt_options = {**default_options, **(opt_options or {})}
     opt_state = optimizer.init(parameters)
     cost_values_over_epochs = []

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -120,12 +120,12 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
     can ask for: if more than four, additional plots will appear in a new row of four,
     and so on.
 
-    Args:
-        plotting_functions _(list[Callable])_: list of functions that each return a plot
+    Parameters:
+        plotting_functions: list of functions that each return a plot
             useful for tracking intermediate results, such as the value of the optimized
             controls, fft of the controls, expectation values, etc. Each function must
             have signature `example_plot_function(ax, expects, model, parameters)` where
-            `ax` is the matplotlib.pyplot.Axes instance where the results are plotted,
+            `ax` is the `matplotlib.pyplot.Axes` instance where the results are plotted,
             `expects` is of type dq.SolveResult.expects (which could be `None`), `model`
             is of type `ql.Model` and `parameters` are the parameters being optimized.
             Of course, some of these arguments may be unused for a particular plot (for
@@ -133,10 +133,9 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
             `parameters`).
 
     Returns:
-        _(Plotter)_: Plotter whose `update_plots` method is repeatedly called during an
-            optimization run.
+        Plotter whose `update_plots` method is repeatedly called during an optimization run.
 
-    Examples:
+    ??? example "Example"
         We plot the controls as well as the expectation values for two different initial
         states
         ```python
@@ -174,12 +173,12 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
         ) -> Axes:
             ax.set_facecolor('none')
             tsave = model.tsave_function(parameters)
-            finer_tsave = np.linspace(0.0, tsave[-1], 10 * len(tsave))
+            finer_tsave = jnp.linspace(0.0, tsave[-1], 10 * len(tsave))
             for idx, control in enumerate(parameters):
                 H_c = dq.pwc(tsave, control, H1s[idx])
                 ax.plot(
                     finer_tsave,
-                    np.real(H_c.prefactor(finer_tsave)) / 2 / np.pi,
+                    np.real(jax.vmap(H_c.prefactor)(finer_tsave)) / 2 / np.pi,
                     label=H1_labels[idx],
                 )
             ax.legend(loc='lower right', framealpha=0.0)

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -133,7 +133,8 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
             `parameters`).
 
     Returns:
-        Plotter whose `update_plots` method is repeatedly called during an optimization run.
+        Plotter whose `update_plots` method is repeatedly called during an optimization
+        run.
 
     ??? example "Example"
         We plot the controls as well as the expectation values for two different initial


### PR DESCRIPTION
Overall summary:
- Removed a bunch of duplicate labels. 
- Reorganized docstrings to use the Google standard. Rewrote the datatypes so mkdocs can format them better. 
- Packaged examples and options into dropdown menus. 
- Added `contributing.md` to the docs (previously only accessible on github) 
- Tabbed mkdocs layout.
- Fixed typo pointed out by #5 .

@dkweiss31 feel free to make changes according to your style. 